### PR TITLE
ci: add pip-list diagnostics & artifact upload for dev-deps check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Diagnostic - pip list (before install)
+        run: |
+          python -m pip --version
+          python -m pip list --format=freeze | sort > pip-list-before.txt || true
+          echo "Wrote pip-list-before.txt"
+          head -n 50 pip-list-before.txt || true
+
       - name: Install pip + deps
         run: |
           python -m pip install --upgrade pip
@@ -43,6 +50,20 @@ jobs:
           # are not installed in CI runtime. This keeps the runtime surface
           # minimal and ensures advisories are surfaced and tracked.
           pip install ruff mypy black pytest coverage bandit safety pytest-asyncio httpx anyio
+
+      - name: Diagnostic - pip list (after install)
+        run: |
+          python -m pip list --format=freeze | sort > pip-list-after.txt || true
+          echo "Wrote pip-list-after.txt"
+          head -n 50 pip-list-after.txt || true
+
+      - name: Upload pip-list artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-lists-ci
+          path: |
+            pip-list-before.txt
+            pip-list-after.txt
 
       # --- Linting ---
       - name: Run Ruff
@@ -66,18 +87,22 @@ jobs:
 
       - name: Check for dev-only packages in runtime (FAILS if any found)
         if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        id: enforce
         run: |
           set -o pipefail
-          python backend/scripts/check_dev_deps_in_runtime.py || (
-            if [ -f backend/dev_in_runtime.txt ]; then
-              pkgs=$(cat backend/dev_in_runtime.txt)
-              echo "::error file=backend/dev_in_runtime.txt::Dev-only packages installed in runtime: $pkgs"
-              echo "See backend/README.md for remediation: https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/backend/README.md"
-            else
-              echo "Dev-deps check failed with non-zero exit code"
-            fi
+          python backend/scripts/check_dev_deps_in_runtime.py || true
+          if [ -f backend/dev_in_runtime.txt ]; then
+            pkgs=$(cat backend/dev_in_runtime.txt)
+            IFS=',' read -ra A <<< "$pkgs"
+            for pkg in "${A[@]}"; do
+              pkg=$(echo "$pkg" | xargs)
+              echo "::error file=backend/dev_in_runtime.txt::Dev-only package installed in runtime: $pkg"
+            done
+            echo "See backend/README.md for remediation: https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/backend/README.md"
             exit 1
-          )
+          else
+            echo "No dev-only packages detected"
+          fi
 
       # --- Tests ---
       - name: Run Pytest with Coverage

--- a/.github/workflows/nightly-dev-check.yml
+++ b/.github/workflows/nightly-dev-check.yml
@@ -21,11 +21,38 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Diagnostic - pip list (before install)
+        run: |
+          python -m pip --version
+          python -m pip list --format=freeze | sort > pip-list-before.txt || true
+          echo "Wrote pip-list-before.txt"
+          head -n 50 pip-list-before.txt || true
+
       - name: Install runtime requirements
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
 
-      - name: Run dev-deps check
+      - name: Diagnostic - pip list (after install)
         run: |
-          python backend/scripts/check_dev_deps_in_runtime.py
+          python -m pip list --format=freeze | sort > pip-list-after.txt || true
+          echo "Wrote pip-list-after.txt"
+          head -n 50 pip-list-after.txt || true
+
+      - name: Upload pip-list artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-lists-${{ matrix.os }}-${{ matrix.python }}
+          path: |
+            pip-list-before.txt
+            pip-list-after.txt
+
+      - name: Run dev-deps check
+        id: devcheck
+        run: |
+          python backend/scripts/check_dev_deps_in_runtime.py || true
+          if [ -f backend/dev_in_runtime.txt ]; then
+            echo "FOUND=$(cat backend/dev_in_runtime.txt)" >> $GITHUB_OUTPUT
+          else
+            echo "FOUND=" >> $GITHUB_OUTPUT
+          fi

--- a/backend/README.md
+++ b/backend/README.md
@@ -63,3 +63,47 @@ You can also run the check locally via the Makefile target from the repo root:
 make -C backend check-dev-deps
 ```
 
+Windows / PowerShell notes
+--------------------------
+Windows developers can use PowerShell to set up and run the same tools:
+
+```powershell
+# Create and activate the venv
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+
+# Install dev deps
+pip install -r backend/requirements-dev.txt
+
+# Run the check
+python backend/scripts/check_dev_deps_in_runtime.py
+```
+
+Repair helper
+-------------
+If the check finds dev-only packages installed at runtime, you can run the
+repair helper to uninstall them (it will prompt for confirmation):
+
+POSIX:
+```bash
+./scripts/repair-dev-deps.sh
+```
+
+PowerShell:
+```powershell
+.\scripts\repair-dev-deps.ps1
+```
+
+Both scripts support a dry-run mode to preview what would be uninstalled:
+
+POSIX:
+```bash
+./scripts/repair-dev-deps.sh --dry-run
+```
+
+PowerShell:
+```powershell
+.\scripts\repair-dev-deps.ps1 -DryRun
+```
+
+


### PR DESCRIPTION
Add pip list diagnostics (before/after runtime installs) and upload artifacts so we can trace where dev-only packages are introduced. Also improve enforcement output to emit per-package errors and link to backend/README.md for remediation.