### PR TITLE
ci: docker publish - add GHCR fallback and permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,23 +7,45 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GitHub Container Registry (fallback)
+        if: secrets.DOCKERHUB_TOKEN == ''
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push Docker image
+      - name: Build and push to Docker Hub
+        if: secrets.DOCKERHUB_TOKEN != ''
         uses: docker/build-push-action@v4
         with:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
-          tags: gemgeminay/quantum_trader:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/quantum_trader:latest
+
+      - name: Build and push to GitHub Container Registry (fallback)
+        if: secrets.DOCKERHUB_TOKEN == ''
+        uses: docker/build-push-action@v4
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/quantum_trader:latest


### PR DESCRIPTION
Add workflow permissions and fallback to GHCR when Docker Hub secrets are not present. This prevents failures when DOCKERHUB_TOKEN isn't configured and allows publishing to GHCR using GITHUB_TOKEN.