### PR TITLE
ci: use GHCR_PAT for GHCR login when available

### DIFF
--- a/.github/GHCR_PAT.md
+++ b/.github/GHCR_PAT.md
@@ -1,0 +1,35 @@
+# Why you might need GHCR_PAT
+
+
+If your organization blocks the default GITHUB_TOKEN from writing packages, the
+workflow `workflow_at_sha.yml` will skip pushing to ghcr.io unless an explicit
+Personal Access Token is provided via the repository secret `GHCR_PAT`.
+
+Create a PAT with these scopes:
+
+- For classic PAT: check `write:packages` and `repo` (if the repo is private).
+- For fine-grained PAT: grant repository access to this repo and the
+  "Packages: Write" permission.
+
+How to add the secret
+----------------------
+
+1. Generate the token:
+   - Open your GitHub tokens page (https://github.com/settings/tokens) and
+     create a new token. Choose a classic PAT or a fine-grained token as
+     preferred.
+   - Click "Generate new token" (classic) or "Generate new fine-grained token"
+   - Select the scopes described above and create the token.
+
+2. Add the repository secret:
+   - Go to the repository page -> Settings -> Secrets -> Actions -> New
+   - Name: GHCR_PAT
+   - Value: paste the token
+   - Save
+
+After adding `GHCR_PAT`, rerun the workflow. The publish job will then log in
+to ghcr.io using the token and attempt to push the image.
+
+If you prefer to allow the workflow to push using the built-in `GITHUB_TOKEN`,
+ask your organization admins to permit package write access for GitHub Actions
+in the organization policies.

--- a/.github/workflows/docker-publish-3.yml
+++ b/.github/workflows/docker-publish-3.yml
@@ -19,13 +19,17 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to GHCR
+        if: secrets.GHCR_PAT != ''
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
+          # Use an explicit PAT so pushes won't fail when org policies block
+          # the default GITHUB_TOKEN from writing packages.
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Build and push image to GHCR
+        if: secrets.GHCR_PAT != ''
         uses: docker/build-push-action@v4
         with:
           context: ./backend

--- a/.github/workflows/docker-publish-3.yml
+++ b/.github/workflows/docker-publish-3.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: GHCR publish skipped notice
+        if: secrets.GHCR_PAT == ''
+        run: |
+          echo "GHCR publish skipped: repository secret GHCR_PAT is not set."
+          echo "To enable publishing to ghcr.io, add a repository secret named GHCR_PAT"
+          echo "containing a Personal Access Token with 'write:packages' (and 'repo' if private) or a fine-grained token with Packages: Write."
+
       - name: Log in to GHCR
         if: secrets.GHCR_PAT != ''
         uses: docker/login-action@v2

--- a/artifacts/frontend-audit.json
+++ b/artifacts/frontend-audit.json
@@ -1,0 +1,22 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {},
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 32,
+      "dev": 399,
+      "optional": 50,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 430
+    }
+  }
+}

--- a/backend/routes/signals.py
+++ b/backend/routes/signals.py
@@ -29,7 +29,9 @@ class PaginatedSignals(BaseModel):
     items: List[Signal]
 
 
-def _generate_mock_signals(count: int, profile: Literal["left", "right", "mixed"]) -> List[Dict]:
+def _generate_mock_signals(
+    count: int, profile: Literal["left", "right", "mixed"]
+) -> List[Dict]:
     symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "ADAUSDT"]
     now = datetime.datetime.now(datetime.timezone.utc)
     signals: List[Dict] = []
@@ -37,7 +39,7 @@ def _generate_mock_signals(count: int, profile: Literal["left", "right", "mixed"
 
     for i in range(count):
         seconds_ago = (count - i) * 15
-        ts = (now - datetime.timedelta(seconds=seconds_ago))
+        ts = now - datetime.timedelta(seconds=seconds_ago)
         symbol = symbols[i % len(symbols)]
 
         base = i / max(1, count - 1)
@@ -59,7 +61,10 @@ def _generate_mock_signals(count: int, profile: Literal["left", "right", "mixed"
                 "side": side,
                 "score": score,
                 "confidence": confidence,
-                "details": {"source": "simulator", "note": f"mock signal #{i} ({profile})"},
+                "details": {
+                    "source": "simulator",
+                    "note": f"mock signal #{i} ({profile})",
+                },
             }
         )
 
@@ -109,4 +114,6 @@ def list_signals(
     # response_model validation uses the Signal model.
     signal_items = [Signal(**it) for it in page_items]
 
-    return PaginatedSignals(total=total, page=page, page_size=page_size, items=signal_items)
+    return PaginatedSignals(
+        total=total, page=page, page_size=page_size, items=signal_items
+    )

--- a/backend/tests/test_signals_api.py
+++ b/backend/tests/test_signals_api.py
@@ -1,6 +1,5 @@
 from fastapi.testclient import TestClient
 from backend.main import app
-import datetime
 
 
 client = TestClient(app)

--- a/workflow_at_sha.yml
+++ b/workflow_at_sha.yml
@@ -21,17 +21,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Log in to GitHub Container Registry (fallback)
-        if: secrets.DOCKERHUB_TOKEN == ''
+      - name: Log in to GitHub Container Registry (only when GHCR_PAT is set)
+        if: secrets.DOCKERHUB_TOKEN == '' && secrets.GHCR_PAT != ''
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          # Prefer a user-provided PAT (GHCR_PAT) when available. This is useful
-          # when organization policies prevent the GITHUB_TOKEN from pushing
-          # packages. If GHCR_PAT is not set, fall back to the default
-          # GITHUB_TOKEN (may be blocked by org policy).
+          # Use an explicit Personal Access Token (GHCR_PAT) so pushes won't
+          # fail when organization policies block GITHUB_TOKEN package writes.
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -46,7 +44,7 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/quantum_trader:latest
 
       - name: Build and push to GitHub Container Registry (fallback)
-        if: secrets.DOCKERHUB_TOKEN == ''
+        if: secrets.DOCKERHUB_TOKEN == '' && secrets.GHCR_PAT != ''
         uses: docker/build-push-action@v4
         with:
           context: ./backend
@@ -54,6 +52,10 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/quantum_trader:latest
 
-      # Optional: If you want to ensure a PAT is used explicitly, set the
-      # repository secret GHCR_PAT to a Personal Access Token that has
-      # "write:packages" (and "repo" if this is a private repo) scopes.
+  # Optional: If you want to ensure a PAT is used explicitly, set the
+  # repository secret GHCR_PAT to a Personal Access Token that has
+  # "write:packages" (and "repo" if this is a private repo) scopes.
+  #
+  # NOTE: The workflow will skip the GHCR build/push when GHCR_PAT is not
+  # set. This avoids failing the run with a 403 when org policies block
+  # the default GITHUB_TOKEN from writing packages.

--- a/workflow_at_sha.yml
+++ b/workflow_at_sha.yml
@@ -52,6 +52,13 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/quantum_trader:latest
 
+      - name: GHCR publish skipped notice
+        if: secrets.DOCKERHUB_TOKEN == '' && secrets.GHCR_PAT == ''
+        run: |
+          echo "GHCR publish skipped: repository secret GHCR_PAT is not set."
+          echo "To enable publishing to ghcr.io, add a repository secret named GHCR_PAT"
+          echo "containing a Personal Access Token with 'write:packages' (and 'repo' if private) or a fine-grained token with Packages: Write."
+
   # Optional: If you want to ensure a PAT is used explicitly, set the
   # repository secret GHCR_PAT to a Personal Access Token that has
   # "write:packages" (and "repo" if this is a private repo) scopes.


### PR DESCRIPTION
Make GHCR login and push conditional on the GHCR_PAT secret to avoid 403 failures when org policies block GITHUB_TOKEN package writes. Includes a short .github/GHCR_PAT.md guide for maintainers.